### PR TITLE
Fixes stored state

### DIFF
--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
@@ -142,7 +142,7 @@ MODULE
 	evaPartDir = (0,0,-1)
 	storable = True
 	storedSize = 20
-	stateless = false
+	stateless = true
 	attachOnPart = true
     bayType = PR_WheelConnector
     bayNode = top


### PR DESCRIPTION
Fixes an issue where the MiniWheel, if removed from a container, used,
and stored in a container, will not attach properly to an EVA kerbal's
back when removed from the container again.

Steps to reproduce:
1. Start with a rover MiniWheel stored in a KAS container. The container must be filled with the RoverWheel in the VAB/SPH.
2. Launch the mission.
3. EVA a kerbal.
4. While on EVA, remove MiniWheel from the KAS container and assemble the PackRat rover.
5. Drive around a bit and return to the vessel.
6. Remove the MiniWheel from the rover and store it in a KAS container.
7. Open the container and Take the MiniWheel from the container.

Expected Result:
Rover MiniWheel should be removed from the KAS container and attached to the EVA kerbal's back.

Actual Result Without Fix
Rover MiniWheel does not attach to the EVA kerbal's back and instead seems to get stuck on the vessel.

Actual Result With Fix
Rover MiniWheel attaches properly to the EVA kerbal's back and can be used again.