### PR TITLE
Safety Light KAS stored size change

### DIFF
--- a/GameData/UmbraSpaceIndustries/ExpPack/SafetyLight/part.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/SafetyLight/part.cfg
@@ -61,7 +61,7 @@ MODULE
 	evaPartPos = (0.0, 0.0, 0.0)        
 	evaPartDir = (0,0,-1)
 	storable = True
-	storedSize = 20
+	storedSize = 5
 	stateless = false
 	attachOnPart = True
 }


### PR DESCRIPTION
With stored size 20 I could fit only 2 lights into the default KAS container. I propose making it 5, because this light is just too small to be that big.