### PR TITLE
PackRat crashTolerance Fixup

### DIFF
--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
@@ -32,7 +32,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 50

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Back.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Back.cfg
@@ -28,7 +28,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Camera.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Camera.cfg
@@ -26,7 +26,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Front.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Front.cfg
@@ -33,7 +33,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Rear.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Rear.cfg
@@ -35,7 +35,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Crate.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Crate.cfg
@@ -27,7 +27,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Front.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Front.cfg
@@ -38,7 +38,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_RoofRack.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_RoofRack.cfg
@@ -30,7 +30,6 @@ dragModelType = default
 maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 1
-crashTolerance = 7
 maxTemp = 3600 
 
 crashTolerance = 20


### PR DESCRIPTION
Dropped part of the PackRat on the Mun and it exploded, so I looked in to the crashTolerance setting and noticed it was duplicated. I believe KSP was using the first-in value, which does not appear to be your intention.