### PR TITLE
Better KIS support for packrat rover

### DIFF
--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
@@ -12,8 +12,8 @@ scale = 1,1,1
 
 rescaleFactor = 1
 
-node_attach = 0.3, 0.322, 0.00, -1.0, 0.0, 0.0, 1
-node_stack_top = 0.3, 0.322, 0.00, -1.0, 0.0, 0.0, 0
+node_attach = 0.3, 0.322, 0.00, 1.0, 0.0, 0.0, 1
+node_stack_top = 0.3, 0.322, 0.00, 1.0, 0.0, 0.0, 0
 
 TechRequired = fieldScience
 entryCost = 5200
@@ -25,7 +25,7 @@ title = PackRat Mini Wheel
 manufacturer = Kerbal Motion LLC
 description = A miniaturized version of the RoveMax Model 1 powered rover wheel for the Pack-Rat Rover
 
-attachRules = 1,1,0,1,0
+attachRules = 1,0,0,0,0
 
 mass = 0.075
 dragModelType = default
@@ -139,4 +139,11 @@ MODULE
     {
         name = FSwheelAlignment
     }
+	
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 50
+		editorItemsCategory = false
+	}
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Back.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Back.cfg
@@ -19,7 +19,7 @@ subcategory = 0
 title = PackRat Rover - Back Section
 manufacturer = Umbra Space Industries
 
-node_stack_core01 =   0,.1,-.06,0,0,-1,0
+node_stack_core01 =   0,.1,-.06,0,0,1,0
 
 attachRules = 1,0,1,1,1
 CoMOffset = 0,-.5,0
@@ -44,5 +44,12 @@ MODULE
 	   rate = 1
 	}	
 }
+
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 100
+		editorItemsCategory = false
+	}
 
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Camera.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Camera.cfg
@@ -52,4 +52,10 @@ breakingTorque = 20
 		
 		rerunnable = True
 	}
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 50
+		editorItemsCategory = false
+	}
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Front.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Front.cfg
@@ -19,11 +19,16 @@ subcategory = 0
 title = PackRat Rover - Chassis Front Section
 manufacturer = Umbra Space Industries
 
+node_stack_core02 = 0,.1,-.885,0,0,1,0
+node_stack_core01 = 0,.1,.32,0,0,1,0
+node_stack_wheel01 = -0.25,0.05,-.72,-1,0,0,0
+node_stack_wheel02 =  0.25,0.05,-.72,1,0,0,0
+node_stack_attach01 = -.35,.22,-.3,0,1,0,0
+node_stack_attach02 = .35,.22,-.3,0,1,0,0
+node_stack_attach07 = 0,.22,-.3,0,1,0,0
+node_stack_top = 0,.85,.35,0,1,0,0
 
-node_stack_wheel01 = -0.25,0.05,-.72,1,0,0,0
-node_stack_wheel02 =  0.25,0.05,-.72,-1,0,0,0
-node_stack_core01 =     0,.1,.32,0,0,1,0
-node_stack_core02 =     0,.1,-.885,0,0,1,0
+
 
 attachRules = 1,0,1,1,0
 
@@ -60,6 +65,23 @@ MODULE
         type = PR_WheelConnector
     }
 }
-
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 100
+		editorItemsCategory = false
+	}
+	
+	MODULE
+	{
+		name = ModuleKISPartMount
+		sndStorePath = KIS/Sounds/containerMount
+		allowRelease = false
+		MOUNT
+		{
+			attachNode = top
+			allowedPartName= PackRat_RoofRack
+		}
+	}
 //***************************************************
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Rear.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Rear.cfg
@@ -22,11 +22,19 @@ subcategory = 0
 title = PackRat Rover - Chassis Rear Section
 manufacturer = Umbra Space Industries
 
+node_stack_core01 = 0,.1,-.89,0,0,-1,0
+node_stack_core02 = 0,.1,.33,0,0,-1,0
+node_stack_wheel01 = -0.25,0.05,.17,-1,0,0,0
+node_stack_wheel02 =  0.25,0.05,.17,1,0,0,0
 
-node_stack_wheel01 = -0.25,0.05,.17,1,0,0,0
-node_stack_wheel02 =  0.25,0.05,.17,-1,0,0,0
-node_stack_core02 =     0,.1,.33,0,0,1,0
-node_stack_core01 =     0,.1,-.89,0,0,-1,0
+node_stack_attach03 = -.35,.22,-.85,0,1,0,0
+node_stack_attach04 = .35,.22,-.85,0,1,0,0
+node_stack_attach08 = 0,.22,-.85,0,1,0,0
+
+node_stack_attach09 = 0,.22,-.25,0,1,0,0
+node_stack_attach05 = -.35,.22,-.25,0,1,0,0
+node_stack_attach06 = .35,.22,-.25,0,1,0,0
+
 
 attachRules = 1,0,1,1,0
 
@@ -63,5 +71,11 @@ MODULE
         type = PR_WheelConnector
     }	
 }
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 100
+		editorItemsCategory = false
+	}
 //***************************************************
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Crate.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Crate.cfg
@@ -19,7 +19,7 @@ subcategory = 0
 title = PackRat Rover - Science Crate
 manufacturer = Umbra Space Industries
 
-node_stack_bottom =   0,-.2,0,0,-1,0,0
+node_stack_bottom = 0,-.2,0,0,-1,0,0
 attachRules = 1,0,1,1,0
 
 mass = 0.05
@@ -42,4 +42,10 @@ MODULE
 	evaOnlyStorage = True
 	storageRange = 1.3
 }
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 100
+		editorItemsCategory = false
+	}
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Front.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Front.cfg
@@ -20,18 +20,9 @@ subcategory = 0
 title = PackRat Rover - Front Section
 manufacturer = Umbra Space Industries
 
-node_stack_core01 =   0,.1,-.85,0,0,-1,0
-node_stack_attach07 = 0,.22,-.3,0,1,0,0
-node_stack_attach08 = 0,.22,.35,0,1,0,0
-node_stack_attach09 = 0,.22,1,0,1,0,0
-node_stack_attach01 = -.35,.22,-.3,0,1,0,0
-node_stack_attach02 = .35,.22,-.3,0,1,0,0
-node_stack_attach03 = -.35,.22,.35,0,1,0,0
-node_stack_attach04 = .35,.22,.35,0,1,0,0
-node_stack_attach05 = -.35,.22,1,0,1,0,0
-node_stack_attach06 = .35,.22,1,0,1,0,0
-node_stack_attach = 0,.85,.35,0,1,0,0
-attachRules = 1,1,1,1,0
+node_stack_core01 = 0,.1,-.85,0,0,-1,0
+
+attachRules = 1,0,1,1,0
 CoMOffset = 0,-.5,0
 mass = 0.05
 dragModelType = default
@@ -65,15 +56,24 @@ useResources = true
 
 MODULE
 {
-	name = ModuleCommand
-	minimumCrew = 0
-	
-	RESOURCE
-	{
-		name = ElectricCharge
-		rate = 0.02777778
-	}
+    name = ModuleCommand
+    minimumCrew = 0
+    
+    RESOURCE
+    {
+        name = ElectricCharge
+        rate = 0.02777778
+    }
 }
+
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 100
+		editorItemsCategory = false
+	}
+	
+
 
 //******************************************
 

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_RoofRack.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_RoofRack.cfg
@@ -20,8 +20,8 @@ subcategory = 0
 title = PackRat Rover - Roof Rack
 manufacturer = Umbra Space Industries
 
-node_stack_core01 =   0,.11,-0.5,0,-1,0,0
-node_stack_core02 =   0,.55,-0.5,0,1,0,0
+node_stack_core01 = 0,.11,-0.5,0,-1,0,0
+node_stack_core02 = 0,.55,-0.5,0,1,0,0
 
 attachRules = 1,0,1,1,0
 
@@ -36,4 +36,10 @@ crashTolerance = 20
 breakingForce = 20
 breakingTorque = 20
 
+	MODULE
+	{
+		name = ModuleKISItem
+		volumeOverride = 100
+		editorItemsCategory = false
+	}
 }


### PR DESCRIPTION
Wheels lost surface attachment and could be attached only to nodes - no
need to press R to switch to top node. Some nodes from front part moved
to chassis parts. Changed orientation of some nodes to opposite. Changed
order of nodes so most appropriate comes first - no need to press R
multiple times looking for good attachment node. Roof may be attached to
floating top node in front chassis without instruments - using container
mount functionality. All parts now have override on KIS volume and fit
into small KIS container. Checked both ways to assemble and all works
for me but in VAP/SPH chassis sometimes connect not from first try. Some
parts have wrong rotation when attaching using KIS - have to rotate 180
degrees while attaching. Removed some whitespaces in node definition -
not sure if that was important but looks like KIS was confused by it
somehow. May need additional polishing and rebalance as it's just
version I play with and it's balanced to my needs.