### PR TITLE
Updated KIS Settings. Removed depricated KAS config

### DIFF
--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/MiniWheel/MiniWheel.cfg
@@ -143,7 +143,8 @@ MODULE
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 50
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Back.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Back.cfg
@@ -48,7 +48,8 @@ MODULE
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 100
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Camera.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Camera.cfg
@@ -55,7 +55,8 @@ breakingTorque = 20
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 50
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Front.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Front.cfg
@@ -46,29 +46,11 @@ breakingTorque = 20
 
 
 
-MODULE
-{
-    name = KASModulePartBay
-    BAY
-    {
-        attachNode = core01
-        type = PR_ChassisConnector
-	}
-    BAY
-    {
-        attachNode = wheel01
-        type = PR_WheelConnector
-    }
-    BAY
-    {
-        attachNode = wheel02
-        type = PR_WheelConnector
-    }
-}
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 100
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 	

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Rear.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Chassis_Rear.cfg
@@ -52,29 +52,11 @@ breakingTorque = 20
 
 
 
-MODULE
-{
-    name = KASModulePartBay
-    BAY
-    {
-        attachNode = core02
-        type = PR_RearConnector
-    }
-    BAY
-    {
-        attachNode = wheel01
-        type = PR_WheelConnector
-    }
-    BAY
-    {
-        attachNode = wheel02
-        type = PR_WheelConnector
-    }	
-}
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 100
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 //***************************************************

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Crate.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Crate.cfg
@@ -45,7 +45,8 @@ MODULE
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 100
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 }

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Front.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_Front.cfg
@@ -58,7 +58,8 @@ useResources = true
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 100
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 	

--- a/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_RoofRack.cfg
+++ b/GameData/UmbraSpaceIndustries/ExpPack/PackRat/PackParts/PackRat_RoofRack.cfg
@@ -39,7 +39,8 @@ breakingTorque = 20
 	MODULE
 	{
 		name = ModuleKISItem
-		volumeOverride = 100
+		equipSlot = Back Pocket
+		carriable = true
 		editorItemsCategory = false
 	}
 }


### PR DESCRIPTION
Removed Depricated KAS configs (issue #63)
Removed KIS Storage override for packrat parts (Issue #65)  KIS handle's storage volume calculation pretty well for non-expandable parts.  Previous config fit an entire packrate into ~800L stored, which is about the same as a docking port.  You could fit 7 packrats in an MKS base module.  Native storage a complete packrat Rover with roof rack takes just shy of 9000L which is a bit more reasonable. 
Added Carriable config to packrat parts.  By letting them take up more storage they become to large to fit in a Kerbal's inventory.  Carriable option allows large parts to be carried on a kerbal's "Back" one at a time.