### PR TITLE
Reduced AES RCS tank dry mass

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/AES/AES_RCSTank.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/AES/AES_RCSTank.cfg
@@ -40,7 +40,7 @@ description = Super small RCS tanks in a 0.625m radial form factor.
 attachRules = 0,1,0,1,0
 
 // --- standard part parameters ---
-mass = 0.05
+mass = 0.015
 dragModelType = default
 maximum_drag = 0.20
 minimum_drag = 0.2


### PR DESCRIPTION
Reduced dry mass of monoprop tank so that mass ratio matches stock small radial tank