### PR TITLE
Add extra attachment points to AES Pod

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/AES/AES.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/AES/AES.cfg
@@ -17,7 +17,8 @@ rescaleFactor = 1.0
 // --- node definitions ---
 // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 node_stack_bottom = 0, -0.31, 0, 0.0, -1.0, 0.0, 0
-
+node_stack_Right = 0.335, 0, 0, 1.0, 0, 0, 0
+node_stack_Left = -0.335, 0, 0, -1.0, 0, 0, 0
 
 // --- editor parameters ---
 TechRequired = precisionEngineering


### PR DESCRIPTION
Allows greater flexibility in how the AES Pod is used, including the ability to make very small rovers when combined with the node attached wheels from the Pack Rat.