### PR TITLE
Community Tech Tree improvements

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SrvPack/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SrvPack/CTT.cfg
@@ -1,19 +1,4 @@
-@PART[USI_Inline_Float_Small]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = enhancedSurvivability
-}
-@PART[USI_Inline_Float_Large]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = enhancedSurvivability
-}
-@PART[DERP_*]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = enhancedSurvivability
-}
-@PART[USI_Radial_Float_Sm]:NEEDS[CommunityTechTree]
-{
-    @TechRequired = enhancedSurvivability
-}
+// Survival Pack Airbag Parts
 @PART[USI_Airbag_Single_01]:NEEDS[CommunityTechTree]
 {
     @TechRequired = enhancedSurvivability
@@ -26,6 +11,70 @@
 {
     @TechRequired = enhancedSurvivability
 }
+
+// Survival Pack DERP Parts
+@PART[DERP_Engine_01]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = precisionPropulsion
+}
+@PART[DERP_Engine_02]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = precisionPropulsion
+}
+@PART[DERP_FuelCan]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = precisionPropulsion
+}
+@PART[DERP_FuelCell]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = largeElectrics
+}
+@PART[DERP_InlineTank]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = precisionPropulsion
+}
+@PART[DERP_POD]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+@PART[DERP_RadialPara]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+@PART[DERP_RingExtension]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+@PART[DERP_ServiceRing]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = advFlightControl
+}
+@PART[DERP_Solar]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = advElectrics
+}
+@PART[DERP_StowageBox]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+@PART[DERP_StowBag]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+
+// Survival Pack Float Parts
+@PART[USI_Inline_Float_Small]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+@PART[USI_Inline_Float_Large]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
+@PART[USI_Radial_Float_Sm]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = enhancedSurvivability
+}
 @PART[USI_Radial_Float_Med]:NEEDS[CommunityTechTree]
 {
     @TechRequired = enhancedSurvivability
@@ -34,8 +83,3 @@
 {
     @TechRequired = enhancedSurvivability
 }
-
-
-
-
-

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SrvPack/DERP2/Parts/DERP_Solar.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SrvPack/DERP2/Parts/DERP_Solar.cfg
@@ -27,7 +27,7 @@ entryCost = 5000
 cost = 250
 category = Electrical
 subcategory = 0
-title = DERP Concentrated Photovoltaic array
+title = DERP Concentrated Photovoltaic Array
 description = A small, double-sided array of solar panels suitable for secondary power in an escape pod.  Includes storage batteries.
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,0,0,0


### PR DESCRIPTION
Primarily this is a change to the Community Tech Tree configuration for the Survival parts sub-folder within the USI Exploration Pack.  I rearranged the CTT.CFG to logically group together the parts based on their existing folder structure within the pack and expanded out a wildcard configuration for the DERP pod parts to distribute them as intended, rather than forcing them all into the enhancedSurvivability node.

I also capitalized the 'a' in Array for the DERP Concentrated Photovoltaic Array for consistency.