### PR TITLE
Fix HERP pod IVA model path

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/HERP/spaces/pod_internal.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/HERP/spaces/pod_internal.cfg
@@ -3,7 +3,7 @@ INTERNAL
 	name = HERPInternal
 	MODEL
 	{
-		model = SubPack/HERP/spaces/HERP_POD_IVA
+		model = UmbraSpaceIndustries/ExpPack/HERP/spaces/HERP_POD_IVA
 	}
 	MODULE
 	{


### PR DESCRIPTION
The game was failing to load the part's IVA because the model path was wrong.